### PR TITLE
Remove the build number pin on Aesara

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   patches:
 
 build:
-  number: 3
+  number: 4
   # The following line seems to do nothing. Place noarch in the build block of individual outputs.
   noarch: python
 
@@ -46,16 +46,11 @@ outputs:
       run:
         - python >=3.7
         - {{ pin_subpackage('aeppl-base', exact=True) }}
-        # This last part with =*_1 is a temporary workaround since there are two
-        # builds for aesara-base v2.7.4 labeled like xyz_0 and abc_1.
-        # In the next version, we should remove this line and uncomment the subsequent
-        # lines.
-        - aesara ==2.7.4=*_2
-        # # As of Aesara v2.7.5, there is a 1-1 correspondence between the "aesara-base"
-        # # package and the "aesara" package of the same version and build number on
-        # # which it depends. Thus the pin from the "aesara-base" package above will
-        # # implicitly transfer here to the "aesara" package.
-        # - aesara >=2.7.5
+        # As of Aesara v2.7.5, there is a 1-1 correspondence between the "aesara-base"
+        # package and the "aesara" package of the same version and build number on
+        # which it depends. Thus the pin from the "aesara-base" package above will
+        # implicitly transfer here to the "aesara" package.
+        - aesara >=2.7.5
     test:
       imports:
         - aeppl


### PR DESCRIPTION
Thanks to the new release of Aesara, we no longer need to pin to a specific build number, allowing me to get rid of the ugly workaround which was in place.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
